### PR TITLE
Updating CLI for ffmpeg and ffprobe Installation paths

### DIFF
--- a/init.py
+++ b/init.py
@@ -3,6 +3,11 @@ from pydub import AudioSegment
 from pydub.generators import WhiteNoise
 from math import *
 from random import *
+import sys
+
+AudioSegment.converter = sys.argv[1] #ffmpeg installation exe dir path
+AudioSegment.ffmpeg = sys.argv[1] #ffmpeg installation exe dir path
+AudioSegment.ffprobe = sys.argv[2] #ffprobe installation exe dir path
 
 def calc_pan(index):
 	return cos(radians(index))


### PR DESCRIPTION
User can provide local installation paths for ffmpeg.exe and ffprobe.exe using command line arguments. 
Command to run the code will be : python init.py <ffmpeg installation dir> <ffprobe installation dir>